### PR TITLE
Use the right path to get VtexIdclientAutCookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.0.8] - 2019-06-14
+
 ## [0.0.7] - 2019-06-14
 ### Added
 - Use `VtexIdclientAutCookie` header in request to catalog.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema",
   "vendor": "vtex",
   "name": "catalog-api-proxy",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "title": "Proxy to VTEX Catalog API that adds production cache headers",
   "credentialType": "absolute",
   "builders": {

--- a/node/handlers/catalog.ts
+++ b/node/handlers/catalog.ts
@@ -7,14 +7,14 @@ const TIMEOUT_MS = 7 * 1000
 const MAX_AGE_S = 2 * 60
 const STALE_IF_ERROR_S = 20 * 60
 
-export const catalog = async (ctx: Context) => {
+export async function catalog(ctx: Context) {
   const {vtex: {account, authToken, operationId, production, route: {params: {path}}, segmentToken, sessionToken}, query, method} = ctx
   let VtexIdclientAutCookie: string | undefined
 
   if (sessionToken) {
     const { session } = ctx.clients
     const sessionPayload = await session.getSession(sessionToken, ['*'])
-    VtexIdclientAutCookie = ramdaPath(['namespaces', 'cookie', `VtexIdclientAutCookie_${account}`], sessionPayload)
+    VtexIdclientAutCookie = ramdaPath(['sessionData', 'namespaces', 'cookie', `VtexIdclientAutCookie_${account}`, 'value'], sessionPayload)
   }
 
   const isGoCommerce = Functions.isGoCommerceAcc(ctx)


### PR DESCRIPTION
This PR fixes the path used to get the `VtexIdclientAutCookie` in the session payload obtained from the `session` api. 

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
