### PR TITLE
Make timeout smaller to leverage stale-if-error cache

### DIFF
--- a/node/service.json
+++ b/node/service.json
@@ -2,8 +2,8 @@
   "stack": "nodejs",
   "memory": 384,
   "ttl": 30,
-  "timeout": 10,
-  "minReplicas": 10,
+  "timeout": 5,
+  "minReplicas": 5,
   "maxReplicas": 40,
   "routes": {
     "catalog": {


### PR DESCRIPTION
Currently, `store-graphql` and `search-graphql` abort requests to `catalog-api-proxy` that take longer than `6s`. This makes the `stale-if-error` cache directive useless, since the router never considers this as an error, but a client cancellation. 

This is an attempt to tighten the timeout and force stale responses from `catalog-api-proxy` to all consumers.