### PR TITLE
Delete duplicated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,0 @@
-# vtex.catalog-api-proxy
-
-Proxy to VTEX Catalog API that adds production cache headers.


### PR DESCRIPTION
A README is already in the docs folder (expected format)

