### PR TITLE
Create a new endpoint for authenticated searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Create a new endpoint for authenticated searches (B2B).
 
 ## [0.8.1] - 2020-05-08
 ### Fixed

--- a/node/globals.ts
+++ b/node/globals.ts
@@ -1,5 +1,9 @@
-import { IOClients, ServiceContext } from '@vtex/api'
+import { IOClients, ServiceContext, RecorderState } from '@vtex/api'
 
 declare global {
-  type Context = ServiceContext<IOClients>
+  interface State extends RecorderState {
+    userAuthToken?: string
+  }
+
+  type Context = ServiceContext<IOClients, State>
 }

--- a/node/index.ts
+++ b/node/index.ts
@@ -2,7 +2,8 @@ import './globals'
 
 import { Service } from '@vtex/api'
 
-import { catalog } from './handlers/catalog'
+import { prepare } from './middlewares/prepare'
+import { request } from './middlewares/request'
 
 const TWO_SECONDS_MS =  2 * 1000
 
@@ -16,6 +17,7 @@ export default new Service({
     }
   },
   routes: {
-    catalog,
+    catalog: [prepare(false), request],
+    authenticatedCatalog: [prepare(true), request],
   }
 })

--- a/node/middlewares/prepare.ts
+++ b/node/middlewares/prepare.ts
@@ -14,7 +14,8 @@ export function prepare (explicitlyAuthenticated: boolean) {
         logger.warn({
           message: 'Using catalog instead of authenticatedCatalog for user authenticated search',
           path: ctx.path,
-          headers: ctx.headers,
+          query: ctx.query,
+          userAgent: ctx.get('user-agent'),
           authenticated: !!VtexIdclientAutCookie
         })
       }

--- a/node/middlewares/prepare.ts
+++ b/node/middlewares/prepare.ts
@@ -1,0 +1,31 @@
+export function prepare (explicitlyAuthenticated: boolean) {
+  return async function prepareMiddleware (ctx: Context, next: () => Promise<void>) {
+    const { vtex: { account, logger, sessionToken }} = ctx
+    let VtexIdclientAutCookie: string | undefined
+
+    if (sessionToken) {
+      const { session } = ctx.clients
+      const sessionPayload = await session.getSession(sessionToken, ['*'])
+
+      const isImpersonated = !!sessionPayload?.sessionData?.namespaces?.impersonate?.storeUserId?.value
+      const vtexIdClientCookieName = isImpersonated ? 'VtexIdclientAutCookie' : `VtexIdclientAutCookie_${account}`
+      VtexIdclientAutCookie = sessionPayload?.sessionData?.namespaces?.cookie?.[vtexIdClientCookieName]?.value
+      if (!explicitlyAuthenticated) {
+        logger.warn({
+          message: 'Using catalog instead of authenticatedCatalog for user authenticated search',
+          path: ctx.path,
+          headers: ctx.headers,
+          authenticated: !!VtexIdclientAutCookie
+        })
+      }
+    }
+
+    ctx.vary('x-vtex-segment')
+    if (VtexIdclientAutCookie || explicitlyAuthenticated) {
+      ctx.vary('x-vtex-session')
+    }
+
+    ctx.state.userAuthToken = VtexIdclientAutCookie
+    await next()
+  }
+}

--- a/node/service.json
+++ b/node/service.json
@@ -9,6 +9,10 @@
     "catalog": {
       "path": "/proxy/catalog/*path",
       "public": false
+    },
+    "authenticatedCatalog": {
+      "path": "/proxy/authenticated/catalog/*path",
+      "public": false
     }
   },
   "workers": 4

--- a/policies.json
+++ b/policies.json
@@ -11,5 +11,18 @@
         ]
       }
     ]
+  },
+  {
+    "name": "authenticated-catalog-proxy",
+    "description": "Allows access to the authenticated catalog proxy route",
+    "statements": [
+      {
+        "actions": ["get"],
+        "effect": "allow",
+        "resources": [
+          "vrn:vtex.catalog-api-proxy:{{region}}:{{account}}:{{workspace}}:/proxy/authenticated/catalog/*"
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
#### What is the purpose of this pull request?
Create a new endpoint to do authenticated searches (B2B).

#### What problem is this solving?
The current behaviour is to always set `vary: x-vtex-session` if a session token comes with the request. That is hurting us with "inconsistent vary header" error when stores have both authenticated and public catalogs (B2B and B2C on the same binding).

This PR creates a new route to make predictable use of `vary` header.

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
