### PR TITLE
Increase max replicas from 40 to 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Increase max replicas from 40 to 100.
 
 ## [0.9.0] - 2020-05-12
 ### Added
@@ -17,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.8.0] - 2020-04-28
 ### Added
-- Adds 4 workers to improve performance
+- Adds 4 workers to improve performance.
 
 ## [0.7.2] - 2020-03-12
 ### Fixed
@@ -33,7 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.6.0] - 2019-12-18
 ### Changed
-- Migrates to node 6.x
+- Migrates to node 6.x.
 
 ## [0.5.0] - 2019-09-19
 

--- a/node/service.json
+++ b/node/service.json
@@ -4,7 +4,7 @@
   "ttl": 30,
   "timeout": 20,
   "minReplicas": 5,
-  "maxReplicas": 40,
+  "maxReplicas": 100,
   "routes": {
     "catalog": {
       "path": "/proxy/catalog/*path",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Increase the maximum number of replicas that this service can have.

#### What problem is this solving?
We reached the current limit at the last big event (Colombia), so we are increasing the limit now to avoid having to do it manually during the event.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
