### PR TITLE
Fix/ensure vary session 401 403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Ensure vary: x-vtex-session for 401 and 403 responses.
 
 ## [0.10.0] - 2020-09-03
 ### Changed

--- a/node/middlewares/request.ts
+++ b/node/middlewares/request.ts
@@ -98,6 +98,10 @@ export async function request(ctx: Context, next: () => Promise<void>) {
     ctx.set(headerKey, headers[headerKey])
   })
 
+  if (ctx.get('x-vtex-session') && (status === 401 || status === 403)) {
+    ctx.vary('x-vtex-session')
+  }
+
   // The 206 from the catalog API is not spec compliant since it doesn't correspond to a Range header,
   // so we normalize it to a 200 in order to cache list results, which vary with query string parameters.
   ctx.status = status === 206 ? 200 : status


### PR DESCRIPTION
#### What is the purpose of this pull request?
Ensure `vary: x-vtex-session` for 401 and 403 responses

#### What problem is this solving?

In the latest version the pagetype endpoint was changed to vary only by segment. But it can make `Unauthorized` or `Forbidden`. It is safer now.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
