### PR TITLE
Scale service vertically for fewer replicas

### DIFF
--- a/node/service.json
+++ b/node/service.json
@@ -1,5 +1,5 @@
 {
-  "memory": 512,
+  "memory": 768,
   "ttl": 30,
   "timeout": 20,
   "minReplicas": 5,

--- a/node/service.json
+++ b/node/service.json
@@ -1,5 +1,4 @@
 {
-  "stack": "nodejs",
   "memory": 512,
   "ttl": 30,
   "timeout": 20,

--- a/node/service.json
+++ b/node/service.json
@@ -1,4 +1,8 @@
 {
+  "cpu": {
+    "type": "shared",
+    "value": 50
+  },
   "memory": 768,
   "ttl": 30,
   "timeout": 20,


### PR DESCRIPTION
#### What is the purpose of this pull request?
This is to reduce the number of replicas this app is scaled up in production.
The current state is that this app was only requesting 512mb of RAM and no
explicit CPU request, which caused it to:
 - Operate close to full memory capacity at ~400mb but sometimes passing the 512mb limit
 - Be allocated too few CPU, only 0.12 of a core by the default `app-operator` logic

I believe the first problem made the GC cause too much processing pressure in
the service, and just by increasing the app memory it already scaled down for 
a few less replicas.

And the second problem made the app be scaled up way too much, running with
~80 replicas in each of our stores clusters and sometimes >100. In this case I
believe it is better to have fewer replicas with a larger size, so its easier to debug
any issues in instances (even grafana frontend hangs trying to display metrics
about 100 replicas), causes less pressure to the k8s control plane, and may be 
even more efficient due to connection pools re-use and cache locality.

#### What problem is this solving?
App being too scaled horizontally by not being scaled enough vertically.

#### How should this be manually tested?
Change the resources in prod and check app still behaves fine.

Already did it, check:
 - [Previous resource allocation on `stores-2b` (80 replicas)](http://grafana.ingress.vtex.io/d/0FbY1kRWk/io-deployments?orgId=1&from=1608059060000&to=1608061320000&var-datasource=prometheus%20stores-2b&var-deployment_namespace=vendor-vtex&var-deployment_name=vtex-catalog-api-prox-0-10-0-867c3fc7cb0ea63)
 - [New resource allocation on `stores-2a` (14 replicas)](http://grafana.ingress.vtex.io/d/0FbY1kRWk/io-deployments?orgId=1&from=1608059060000&to=1608061320000&var-datasource=prometheus%20stores-2a&var-deployment_namespace=vendor-vtex&var-deployment_name=vtex-catalog-api-prox-0-10-0-867c3fc7cb0ea63)
 - [No relevant impact in request latency or errors](https://splunk7.vtex.com/en-US/app/vtex_kuberouter/search?q=search%20index%3Dkuberouter%20ClusterId%3Dstores-*%20kpi_name%3DServiceLatency%20serviceName%20IN%20(vtex.catalog-api-proxy%400.10.0)%0A%7C%20eval%20err_count%3Dif(status%3E%3D400%2C%20kpi_count%2C%200)%0A%7C%20eval%20key%3DserviceName%2B%22%20%40%20%22%2BClusterId%0A%7C%20timechart%20minspan%3D1m%20eval(sum(kpi_sum)%2Fsum(kpi_count))%20as%20avg%20sum(err_count)%20as%20err_count%20sum(kpi_count)%20as%20count%20by%20key&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1608059060&latest=1608061320&display.general.type=visualizations&display.page.search.tab=visualizations&display.visualizations.trellis.enabled=1&display.visualizations.charting.legend.placement=right&display.visualizations.charting.axisTitleX.visibility=visible&display.visualizations.charting.axisTitleY.visibility=visible&display.visualizations.charting.axisTitleY2.visibility=visible&display.visualizations.trellis.size=large&display.visualizations.trellis.scales.shared=0&display.visualizations.trellis.splitBy=_aggregation&display.visualizations.chartHeight=1353&sid=1608062154.87345_FDE8474F-39D2-434A-ACAC-9C935EADC2A8)
 - [No relevant impact in timeouts](https://splunk7.vtex.com/en-US/app/vtex_kuberouter/search?q=search%20index%3Dkuberouter%20ClusterId%3Dstores-*%20kpi_name%3DServiceTimeout%20Receiver%20IN%20(vtex.catalog-api-proxy%400.10.0)%0A%7C%20eval%20key%3DReceiver%2B%22%20%40%20%22%2BClusterId%0A%7C%20timechart%20minspan%3D1m%20eval(sum(kpi_sum)%2Fsum(kpi_count))%20as%20avg%20sum(kpi_count)%20as%20count%20by%20key&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1608059060&latest=1608061320&display.general.type=visualizations&display.page.search.tab=visualizations&display.visualizations.trellis.enabled=1&display.visualizations.charting.legend.placement=right&display.visualizations.charting.axisTitleX.visibility=visible&display.visualizations.charting.axisTitleY.visibility=visible&display.visualizations.charting.axisTitleY2.visibility=visible&display.visualizations.trellis.size=large&display.visualizations.trellis.scales.shared=0&display.visualizations.trellis.splitBy=_aggregation&display.visualizations.chartHeight=1353&sid=1608062193.87348_FDE8474F-39D2-434A-ACAC-9C935EADC2A8)

#### Types of changes
- [x] Chore/Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
