### PR TITLE
Downsample warnings about using catalog instead of authenticatedCatalog

### DIFF
--- a/node/middlewares/prepare.ts
+++ b/node/middlewares/prepare.ts
@@ -10,7 +10,7 @@ export function prepare (explicitlyAuthenticated: boolean) {
       const isImpersonated = !!sessionPayload?.sessionData?.namespaces?.impersonate?.storeUserId?.value
       const vtexIdClientCookieName = isImpersonated ? 'VtexIdclientAutCookie' : `VtexIdclientAutCookie_${account}`
       VtexIdclientAutCookie = sessionPayload?.sessionData?.namespaces?.cookie?.[vtexIdClientCookieName]?.value
-      if (!explicitlyAuthenticated) {
+      if (!explicitlyAuthenticated && Math.floor(Math.random() * 100) === 0) {
         logger.warn({
           message: 'Using catalog instead of authenticatedCatalog for user authenticated search',
           path: ctx.path,


### PR DESCRIPTION
#### What is the purpose of this pull request?
The warning that is being sampled is one of the most frequent messages being logged to splunk, but there's no active investigation using it. This PR samples 1:100 the number of logs.

#### What problem is this solving?
Overuse of splunk

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
